### PR TITLE
Update microTimeLib.h

### DIFF
--- a/microTimeLib.h
+++ b/microTimeLib.h
@@ -129,7 +129,7 @@ time_t  now(uint32_t& sysTimeMicros); // return the current time as seconds and 
 
 #endif
 #ifdef usePPS
-void    syncToPPS();
+void    IRAM_ATTR syncToPPS();
 #endif
 void    setTime(time_t t);
 void    setTime(int hr,int min,int sec,int day, int month, int yr);


### PR DESCRIPTION
added IRAM_ATTR to SyncToPPS, this ensures the pps sync can come from an ISR routine (i.e. external 1sec pps interrupt line)