### PR TITLE
Update microTime.cpp

### DIFF
--- a/microTime.cpp
+++ b/microTime.cpp
@@ -279,7 +279,7 @@ time_t sysUnsyncedTime = 0; // the time sysTime unadjusted by sync
 #endif
 
 #ifdef usePPS
-void SyncToPPS()
+void IRAM_ATTR SyncToPPS()
 {
   sysTime++;
   prevMicros = micros();


### PR DESCRIPTION
added IRAM_ATTR to SyncToPPS, this ensures the pps sync can come from an ISR routine (i.e. external 1sec pps interrupt line)